### PR TITLE
Add XML documentation

### DIFF
--- a/src/DuplicateHandling.cs
+++ b/src/DuplicateHandling.cs
@@ -1,12 +1,28 @@
 namespace ChatAIze.SemanticIndex;
 
+/// <summary>
+/// Defines how the <see cref="SemanticDatabase{T}"/> should handle duplicate
+/// items when adding records.
+/// </summary>
 public enum DuplicateHandling
 {
+    /// <summary>
+    /// Always add the item even if a duplicate already exists.
+    /// </summary>
     Allow,
 
+    /// <summary>
+    /// Replace the existing record when a duplicate is added.
+    /// </summary>
     Update,
 
+    /// <summary>
+    /// Ignore the new item when a duplicate exists.
+    /// </summary>
     Skip,
 
+    /// <summary>
+    /// Throw an <see cref="InvalidOperationException"/> if a duplicate exists.
+    /// </summary>
     Throw
 }

--- a/src/SemanticRecord.cs
+++ b/src/SemanticRecord.cs
@@ -2,8 +2,20 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ChatAIze.SemanticIndex;
 
+/// <summary>
+/// Represents an item stored in the <see cref="SemanticDatabase{T}"/> along
+/// with its vector embedding.
+/// </summary>
+/// <typeparam name="T">The type of the stored item.</typeparam>
 public record SemanticRecord<T>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SemanticRecord{T}"/> class
+    /// with the specified item and embedding.
+    /// </summary>
+    /// <param name="item">The item to store.</param>
+    /// <param name="embedding">The vector embedding associated with the
+    /// item.</param>
     [SetsRequiredMembers]
     public SemanticRecord(T item, float[] embedding)
     {
@@ -11,7 +23,13 @@ public record SemanticRecord<T>
         Embedding = embedding;
     }
 
+    /// <summary>
+    /// Gets or sets the stored item.
+    /// </summary>
     public virtual required T Item { get; set; }
 
+    /// <summary>
+    /// Gets or sets the vector embedding for the item.
+    /// </summary>
     public virtual required float[] Embedding { get; set; }
 }


### PR DESCRIPTION
## Summary
- document `DuplicateHandling` enum
- document `SemanticRecord` record
- document `SemanticDatabase` class and its members
- clarify XML docs that ApiKey represents an OpenAI API key

## Testing
- `dotnet build -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f471824048321aa418b70b29f0921